### PR TITLE
Fixed issue with Python 3 compatibility

### DIFF
--- a/domaintools/sphinxcontrib/domaintools.py
+++ b/domaintools/sphinxcontrib/domaintools.py
@@ -126,7 +126,7 @@ class CustomDomain(Domain):
                             labelid, contnode)
 
     def get_objects(self):
-        for (type, name), info in self.data['objects'].iteritems():
+        for (type, name), info in self.data['objects'].items():
             yield (name, name, type, info[0], info[1],
                    self.object_types[type].attrs['searchprio'])
 


### PR DESCRIPTION
Line 129 of domaintools.py was `        for (type, name), info in self.data['objects'].iteritems():` which causes the error 
`Exception occurred:
  File "/usr/lib/python3.5/site-packages/sphinxcontrib/domaintools.py", line 129, in get_objects
    for (type, name), info in self.data['objects'].iteritems():
AttributeError: 'dict' object has no attribute 'iteritems'
`
to be raised when building in sphinx. This is fixed by replacing iteritems() with items() as iteritems was removed in python3 and the functionality translated to items